### PR TITLE
Add error handling2

### DIFF
--- a/DataChef/ingredient.py
+++ b/DataChef/ingredient.py
@@ -12,7 +12,7 @@ class Ingredient():
     """
 
 
-    def __init__(self, func, label, error_func=None, **kwargs):
+    def __init__(self, func, label, error_func=None, error_func_kwargs={}, **kwargs):
         """Ingredient constructor
         
         Create an ingredient object containing a function representation, 
@@ -24,11 +24,14 @@ class Ingredient():
                 identify distinguish amongst other ingredients
             error_func (:obj:`function`): function that generates an array of error values 
                 if given an x array 
+            error_func (:obj:`dict`): kwargs to be passed to the error function
+
         """
         self.func = func
         self.kwargs = kwargs
         self.label = label
         self.error_func = error_func
+        self.error_func_kwargs = error_func_kwargs
         # self.error_kwargs = error_kwargs
 
     def plot(self, x):
@@ -66,7 +69,7 @@ class Ingredient():
         if yerr is not None:
             y = unumpy.uarray(y, yerr)
         elif callable(self.error_func):
-            yerr = self.error_func(**self.kwargs)
+            yerr = self.error_func(x, **self.error_func_kwargs)
             y = unumpy.uarray(y, yerr) 
 
         return y
@@ -82,4 +85,4 @@ class Ingredient():
             error_func (:obj:`function`): function that generates an array of error values 
                 if given an x array 
         """
-        return error_func(x, **self.error_kwargs)
+        return error_func(x, **self.error_func_kwargs)

--- a/DataChef/ingredient.py
+++ b/DataChef/ingredient.py
@@ -44,7 +44,7 @@ class Ingredient():
             x (:obj:`array`): numpy array or list of floats or ints. Grid on which to 
                 evaluate the ingredient function and plot against.
         """
-        plt.plot(x, self.eval(x), marker='.', c='k')
+        plt.plot(x, self.eval(x, ignore_errors=True), marker='.', c='k')
         plt.title(f"Ingredient '{self.label}'")
     
     def eval(self, x, yerr=None, ignore_errors=False):
@@ -85,4 +85,5 @@ class Ingredient():
             error_func (:obj:`function`): function that generates an array of error values 
                 if given an x array 
         """
+        # TO DO: Check if this function is unecessary
         return error_func(x, **self.error_func_kwargs)

--- a/DataChef/ingredient.py
+++ b/DataChef/ingredient.py
@@ -59,6 +59,11 @@ class Ingredient():
                 the error bar at each point in the `x` grid. Overrides the err_func. Must have
                 the same dimensions as `x`.
             ignore_errors (:obj:`bool`, optional): if True, will evaluate without y errors  
+
+        Returns:
+            y (:obj:`array` or :obj:`uarray`): an array of the y values evaluated from the x grid.
+                If an `error_func` or `yerr` was provided, `y` will be a unumpy.uarray object, containing
+                information for both the y value and its associated errorbar.
         """
         y = self.func(x, **self.kwargs)
 

--- a/DataChef/ingredient.py
+++ b/DataChef/ingredient.py
@@ -12,7 +12,7 @@ class Ingredient():
     """
 
 
-    def __init__(self, func, label, error_func=None, error_func_kwargs={}, **kwargs):
+    def __init__(self, func, label, error_func=None, error_func_kwargs={'scale':2}, **kwargs):
         """Ingredient constructor
         
         Create an ingredient object containing a function representation, 

--- a/DataChef/ingredient_functions.py
+++ b/DataChef/ingredient_functions.py
@@ -1,4 +1,6 @@
 import numpy as np
+from uncertainties import unumpy
+
 
 def line(x, m=1, b=0):
     '''Function to make a straight line with slope m and intercept b.

--- a/DataChef/main.py
+++ b/DataChef/main.py
@@ -5,64 +5,71 @@ from recipe import Recipe
 from ingredient import Ingredient
 import ingredient_functions as ing_funcs
 import mix_functions as mix_funcs
+from uncertainties import unumpy
 
 if __name__ == "__main__":
     # make some ingredients for testing
-    ing  = Ingredient(ing_funcs.line, "line", is_signal=True, m=10, b=1)
-    ing2 = Ingredient(ing_funcs.line, "line", is_signal=True, m=-5, b=1)
-    ing3 = Ingredient(ing_funcs.white_noise, "white noise", is_signal=False, scale=1.5, shift=2)
+    ing  = Ingredient(ing_funcs.line, "line", m=10, b=1)
+    ing2 = Ingredient(ing_funcs.line, "line", m=-5, b=1)
+    ing3 = Ingredient(ing_funcs.poisson, "poisson noise")
 
-    # mini recipe
-    m1 = Ingredient(ing_funcs.parabola, "parabola", True, a=1, b=2, c=1)
-    m2 = Ingredient(ing_funcs.white_noise, "white noise", is_signal=False, scale=1.5)
-    minirecipe = Recipe()
-    minirecipe.add_ingredient(m1, mix_funcs.add)
-    minirecipe.add_ingredient(m2, mix_funcs.add)
-
-    # Run test function on an ingredient
-    # ing.test(np.linspace(0,10,11))
-
-    ing_line  = Ingredient(ing_funcs.line, "line",m=10, b=1)
-    ing_parab = Ingredient(ing_funcs.parabola, "parabola", a=-2, b=0, c=3)
-    ing_cubic = Ingredient(ing_funcs.cubic, "cubic", a=2, b=0, c=0, d=-5)
-    ing_sine = Ingredient(ing_funcs.sinusoid, "sinusoid", phase=0, amplitude=4, period=np.pi)
-    
-    ing_unif = Ingredient(ing_funcs.uniform, "white noise", shift=0, scale=5)
-    ing_gaus = Ingredient(ing_funcs.gaussian, "gaussian", mean=5, stdev=2)
-    ing_pois = Ingredient(ing_funcs.poisson, "poisson", lam=2)
-
-    # ingredients that use a custom function
-    # def custom(x, a, b, c):
-    #     print(a,b,c)
-    #     return a*x + b + c
-    # ing_cust = Ingredient(custom, "custom", a=1, b=2, c=3)
-    
-    # add ingredients to the Recipe
-    recipe = Recipe()
-    recipe.add_ingredient(ing , mix_funcs.add)
-    recipe.add_ingredient(ing2, mix_funcs.add)
-    recipe.add_ingredient(ing3, mix_funcs.add)
-    recipe.add_recipe(minirecipe)
-
-    rec = Recipe()
-    rec.add_ingredient(ing_sine, mix_funcs.add)
-    rec.add_ingredient(ing_parab, mix_funcs.add)
-    rec.add_ingredient(ing_unif, mix_funcs.add)
-
-    # Cook the recipe
-    x = np.linspace(-10,10,101)
-    y, ing_eval, ing_comp = rec.cook_recipe(x, export_eval='output/eval_test.csv', 
-                                               export_cum='output/cum_test.csv')
-
-    # test print_recipe()
-    rec.print()
-    rec.plot(x)
+    x = np.linspace(0,10,11)
+    yerr = [.1] * len(x)
+    y = ing.eval(x, yerr=yerr)
+    plt.plot(x, unumpy.nominal_values(y))
     plt.show()
 
+    # # mini recipe
+    # m1 = Ingredient(ing_funcs.parabola, "parabola", True, a=1, b=2, c=1)
+    # m2 = Ingredient(ing_funcs.white_noise, "white noise", is_signal=False, scale=1.5)
+    # minirecipe = Recipe()
+    # minirecipe.add_ingredient(m1, mix_funcs.add)
+    # minirecipe.add_ingredient(m2, mix_funcs.add)
 
-    # plot each indiviual ingredient
-    for i in range(len(recipe.ingredients)):
-        plt.plot(x, ing_eval[i])
-        plt.show()
+    # # Run test function on an ingredient
+    # # ing.test(np.linspace(0,10,11))
+
+    # ing_line  = Ingredient(ing_funcs.line, "line",m=10, b=1)
+    # ing_parab = Ingredient(ing_funcs.parabola, "parabola", a=-2, b=0, c=3)
+    # ing_cubic = Ingredient(ing_funcs.cubic, "cubic", a=2, b=0, c=0, d=-5)
+    # ing_sine = Ingredient(ing_funcs.sinusoid, "sinusoid", phase=0, amplitude=4, period=np.pi)
+    
+    # ing_unif = Ingredient(ing_funcs.uniform, "white noise", shift=0, scale=5)
+    # ing_gaus = Ingredient(ing_funcs.gaussian, "gaussian", mean=5, stdev=2)
+    # ing_pois = Ingredient(ing_funcs.poisson, "poisson", lam=2)
+
+    # # ingredients that use a custom function
+    # # def custom(x, a, b, c):
+    # #     print(a,b,c)
+    # #     return a*x + b + c
+    # # ing_cust = Ingredient(custom, "custom", a=1, b=2, c=3)
+    
+    # # add ingredients to the Recipe
+    # recipe = Recipe()
+    # recipe.add_ingredient(ing , mix_funcs.add)
+    # recipe.add_ingredient(ing2, mix_funcs.add)
+    # recipe.add_ingredient(ing3, mix_funcs.add)
+    # recipe.add_recipe(minirecipe)
+
+    # rec = Recipe()
+    # rec.add_ingredient(ing_sine, mix_funcs.add)
+    # rec.add_ingredient(ing_parab, mix_funcs.add)
+    # rec.add_ingredient(ing_unif, mix_funcs.add)
+
+    # # Cook the recipe
+    # x = np.linspace(-10,10,101)
+    # y, ing_eval, ing_comp = rec.cook_recipe(x, export_eval='output/eval_test.csv', 
+    #                                            export_cum='output/cum_test.csv')
+
+    # # test print_recipe()
+    # rec.print()
+    # rec.plot(x)
+    # plt.show()
+
+
+    # # plot each indiviual ingredient
+    # for i in range(len(recipe.ingredients)):
+    #     plt.plot(x, ing_eval[i])
+    #     plt.show()
         
 

--- a/DataChef/main.py
+++ b/DataChef/main.py
@@ -9,7 +9,8 @@ from uncertainties import unumpy
 
 if __name__ == "__main__":
     # make some ingredients for testing
-    ing  = Ingredient(ing_funcs.line, "line", error_func=ing_funcs.uniform, m=10, b=1)
+    ing  = Ingredient(ing_funcs.line, "line", m=10, b=1,
+                        error_func=ing_funcs.uniform, error_func_kwargs={'scale':10})
     ing2 = Ingredient(ing_funcs.line, "line", m=-5, b=1)
     ing3 = Ingredient(ing_funcs.poisson, "poisson noise")
 
@@ -17,8 +18,10 @@ if __name__ == "__main__":
     yerr = [.1] * len(x)
     # y = ing.eval(x, yerr=yerr)
     y = ing.eval(x)
-    plt.plot(x, unumpy.nominal_values(y))
-    plt.show()
+    print(y)
+    # ing.plot(x)
+    # plt.plot(x, unumpy.nominal_values(y))
+    # plt.show()
 
     # # mini recipe
     # m1 = Ingredient(ing_funcs.parabola, "parabola", True, a=1, b=2, c=1)
@@ -30,14 +33,21 @@ if __name__ == "__main__":
     # # Run test function on an ingredient
     # # ing.test(np.linspace(0,10,11))
 
-    ing_line  = Ingredient(ing_funcs.line, "line",m=10, b=1)
-    ing_parab = Ingredient(ing_funcs.parabola, "parabola", a=-2, b=0, c=3)
-    ing_cubic = Ingredient(ing_funcs.cubic, "cubic", a=2, b=0, c=0, d=-5)
-    ing_sine = Ingredient(ing_funcs.sinusoid, "sinusoid", phase=0, amplitude=4, period=np.pi)
+    ing_line  = Ingredient(ing_funcs.line, "line",m=10, b=1,
+                        error_func=ing_funcs.uniform, error_func_kwargs={'scale':10})
+    ing_parab = Ingredient(ing_funcs.parabola, "parabola", a=-2, b=0, c=3,
+                        error_func=ing_funcs.uniform, error_func_kwargs={'scale':10})
+    ing_cubic = Ingredient(ing_funcs.cubic, "cubic", a=2, b=0, c=0, d=-5,
+                        error_func=ing_funcs.uniform, error_func_kwargs={'scale':10})
+    ing_sine = Ingredient(ing_funcs.sinusoid, "sinusoid", phase=0, amplitude=4, period=np.pi,
+                        error_func=ing_funcs.uniform, error_func_kwargs={'scale':10})
     
-    ing_unif = Ingredient(ing_funcs.uniform, "white noise", shift=0, scale=5)
-    ing_gaus = Ingredient(ing_funcs.gaussian, "gaussian", mean=5, stdev=2)
-    ing_pois = Ingredient(ing_funcs.poisson, "poisson", lam=2)
+    ing_unif = Ingredient(ing_funcs.uniform, "white noise", shift=0, scale=5,
+                        error_func=ing_funcs.uniform, error_func_kwargs={'scale':10})
+    ing_gaus = Ingredient(ing_funcs.gaussian, "gaussian", mean=5, stdev=2,
+                        error_func=ing_funcs.uniform, error_func_kwargs={'scale':10})
+    ing_pois = Ingredient(ing_funcs.poisson, "poisson", lam=2,
+                        error_func=ing_funcs.uniform, error_func_kwargs={'scale':10})
 
     # # ingredients that use a custom function
     # # def custom(x, a, b, c):
@@ -59,8 +69,10 @@ if __name__ == "__main__":
 
     # Cook the recipe
     x = np.linspace(-10,10,101)
-    yerr = [.1]*len(x)
-    # y, ing_eval, ing_comp = rec.cook_recipe(x, yerr=yerr)
+    # yerr = [.1]*len(x)
+    y, ing_eval, ing_comp = rec.cook_recipe(x)
+
+    print('end')
 
     # # test print_recipe()
     # rec.print()

--- a/DataChef/main.py
+++ b/DataChef/main.py
@@ -9,13 +9,14 @@ from uncertainties import unumpy
 
 if __name__ == "__main__":
     # make some ingredients for testing
-    ing  = Ingredient(ing_funcs.line, "line", m=10, b=1)
+    ing  = Ingredient(ing_funcs.line, "line", error_func=ing_funcs.uniform, m=10, b=1)
     ing2 = Ingredient(ing_funcs.line, "line", m=-5, b=1)
     ing3 = Ingredient(ing_funcs.poisson, "poisson noise")
 
     x = np.linspace(0,10,11)
     yerr = [.1] * len(x)
-    y = ing.eval(x, yerr=yerr)
+    # y = ing.eval(x, yerr=yerr)
+    y = ing.eval(x)
     plt.plot(x, unumpy.nominal_values(y))
     plt.show()
 
@@ -29,14 +30,14 @@ if __name__ == "__main__":
     # # Run test function on an ingredient
     # # ing.test(np.linspace(0,10,11))
 
-    # ing_line  = Ingredient(ing_funcs.line, "line",m=10, b=1)
-    # ing_parab = Ingredient(ing_funcs.parabola, "parabola", a=-2, b=0, c=3)
-    # ing_cubic = Ingredient(ing_funcs.cubic, "cubic", a=2, b=0, c=0, d=-5)
-    # ing_sine = Ingredient(ing_funcs.sinusoid, "sinusoid", phase=0, amplitude=4, period=np.pi)
+    ing_line  = Ingredient(ing_funcs.line, "line",m=10, b=1)
+    ing_parab = Ingredient(ing_funcs.parabola, "parabola", a=-2, b=0, c=3)
+    ing_cubic = Ingredient(ing_funcs.cubic, "cubic", a=2, b=0, c=0, d=-5)
+    ing_sine = Ingredient(ing_funcs.sinusoid, "sinusoid", phase=0, amplitude=4, period=np.pi)
     
-    # ing_unif = Ingredient(ing_funcs.uniform, "white noise", shift=0, scale=5)
-    # ing_gaus = Ingredient(ing_funcs.gaussian, "gaussian", mean=5, stdev=2)
-    # ing_pois = Ingredient(ing_funcs.poisson, "poisson", lam=2)
+    ing_unif = Ingredient(ing_funcs.uniform, "white noise", shift=0, scale=5)
+    ing_gaus = Ingredient(ing_funcs.gaussian, "gaussian", mean=5, stdev=2)
+    ing_pois = Ingredient(ing_funcs.poisson, "poisson", lam=2)
 
     # # ingredients that use a custom function
     # # def custom(x, a, b, c):
@@ -51,15 +52,15 @@ if __name__ == "__main__":
     # recipe.add_ingredient(ing3, mix_funcs.add)
     # recipe.add_recipe(minirecipe)
 
-    # rec = Recipe()
-    # rec.add_ingredient(ing_sine, mix_funcs.add)
-    # rec.add_ingredient(ing_parab, mix_funcs.add)
-    # rec.add_ingredient(ing_unif, mix_funcs.add)
+    rec = Recipe()
+    rec.add_ingredient(ing_sine, mix_funcs.add)
+    rec.add_ingredient(ing_parab, mix_funcs.add)
+    rec.add_ingredient(ing_unif, mix_funcs.add)
 
-    # # Cook the recipe
-    # x = np.linspace(-10,10,101)
-    # y, ing_eval, ing_comp = rec.cook_recipe(x, export_eval='output/eval_test.csv', 
-    #                                            export_cum='output/cum_test.csv')
+    # Cook the recipe
+    x = np.linspace(-10,10,101)
+    yerr = [.1]*len(x)
+    # y, ing_eval, ing_comp = rec.cook_recipe(x, yerr=yerr)
 
     # # test print_recipe()
     # rec.print()

--- a/DataChef/main.py
+++ b/DataChef/main.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     # Cook the recipe
     x = np.linspace(-10,10,101)
     # yerr = [.1]*len(x)
-    y, ing_eval, ing_comp = rec.cook_recipe(x)
+    y, ing_eval, ing_comp, err_ing, err_cum = rec.cook_recipe(x)
 
     print('end')
 

--- a/DataChef/recipe.py
+++ b/DataChef/recipe.py
@@ -95,8 +95,16 @@ class Recipe():
 
         Returns:
             y (:obj:`1D array`): The y values calculated by the recipe
-            ings_evaluated (:obj:`2D array`): Stores the output of ingredient.eval() for each ingredient in the recipe. The `i`th row corresponds to ingredient at the `i`th step of the recipe.
-            cumulative (:obj:`2D array`): Stores the y-values at each step of the recipe. The `i`th row corresponds the `i`th step of the recipe.
+            ings_evaluated (:obj:`2D array`): Stores the output of ingredient.eval() for each 
+                ingredient in the recipe. The `i`th row corresponds to ingredient at the `i`th 
+                step of the recipe.
+            cumulative (:obj:`2D array`): Stores the y-values at each step of the recipe. The 
+                `i`th row corresponds the `i`th step of the recipe.
+            errs_evaluated (:obj:`2D array`): Stores the errorbars from ingredient.eval() for each 
+                ingredient in the recipe. The `i`th row corresponds to ingredient at the `i`th 
+                step of the recipe.
+            errs_cumulative (:obj:`2D array`): Stores the errorbars at each step of the recipe. The 
+                `i`th row corresponds the `i`th step of the recipe.
         """
         # TO DO: Make compatible with grids of higher dimention
 

--- a/DataChef/recipe.py
+++ b/DataChef/recipe.py
@@ -1,5 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from uncertainties import unumpy
+
 
 class Recipe():
     """A list of steps to cook up a simulated data set.
@@ -73,7 +75,8 @@ class Recipe():
             grid (:obj:`1D array`): The x grid that the recipe will be evaluated on
             seed (:obj:`int`, optional): A seed for random number generation via the numpy package.
         """
-        final, _, _ = Recipe.cook_recipe(self, grid, seed)
+        output = Recipe.cook_recipe(self, grid, seed)
+        final = output[0]
         plt.plot(grid, final, marker='.', c='k')
         ing_labels = ""
         for ing in self.ingredients:
@@ -100,23 +103,32 @@ class Recipe():
         if seed is not None:
             np.random.seed(seed)
 
-        # array to store the y array for each ingredient evaluated over the grid
+        # array to store the y and yerr array for each ingredient evaluated over the grid
         ings_evaluated = np.zeros((len(self.ingredients),len(grid)))
+        errs_evaluated = np.zeros((len(self.ingredients),len(grid)))
+
         # array to store the state of the "base" after each ingredient is added
         cumulative = np.zeros((len(self.ingredients),len(grid)))
+        errs_cumulative = np.zeros((len(self.ingredients),len(grid)))
+
 
         # add in the first ingredient
-        ings_evaluated[0] = self.ingredients[0].eval(grid)
-        cumulative[0] = self.ingredients[0].eval(grid)
+        y = self.ingredients[0].eval(grid)
+        ings_evaluated[0] = unumpy.nominal_values(y)
+        errs_evaluated[0] = unumpy.std_devs(y)
+        cumulative[0] = unumpy.nominal_values(y)
+        errs_cumulative[0] = unumpy.std_devs(y)
         
         # loop through the ingredients and add them in
         for idx, (ing, mix) in enumerate(zip(self.ingredients[1:], self.mix_funcs[1:])) :
             # evaluate the ingredient on the grid
             y = ing.eval(grid)
-            ings_evaluated[idx+1,:] = y
+            ings_evaluated[idx+1,:] = unumpy.nominal_values(y)
+            errs_evaluated[idx+1,:] = unumpy.std_devs(y)
 
             # mix the ingredient into the dish
-            cumulative[idx+1] = mix(cumulative[idx],y)
+            cumulative[idx+1] = unumpy.nominal_values(mix(cumulative[idx],y))
+            errs_cumulative[idx+1] = unumpy.std_devs(mix(cumulative[idx],y))
 
         # export the evaluated ingredient to csv
         if export_eval is not None:
@@ -124,4 +136,4 @@ class Recipe():
         if export_cum is not None:
             np.savetxt(fname=export_cum, X=cumulative)
             
-        return cumulative[-1], ings_evaluated, cumulative
+        return cumulative[-1], ings_evaluated, cumulative, errs_evaluated, errs_cumulative

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 matplotlib
+uncertainties


### PR DESCRIPTION
Incorporates error bar calculation and handling into the code. Now, you can specify and error function or provide y-errors when you call Ingredient.eval(), and cook_recipe() calculates the error propagation when it applies a recipe to an x grid. Note that this update changes the number of outputs from cook_recipe() from 3 to 5, and that the package now has a dependency on the `uncertainties` python package.